### PR TITLE
#39 create crudbutton component

### DIFF
--- a/app/components/ui/CrudButton.tsx
+++ b/app/components/ui/CrudButton.tsx
@@ -26,29 +26,26 @@ const CrudButton: React.FC<CrudButtonProps> = ({ kind, ...props }) => {
 export default CrudButton;
 
 const kindCreate = (
-    <svg width="20" height="20" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" >
+    <svg width="20" height="20" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
         <title>Create</title>
-        <path fillRule="evenodd" d="M11 13v5h2v-5h5v-2h-5V6h-2v5H6v2h5Z" clipRule="evenodd" />
+        <path d="M11 13v5h2v-5h5v-2h-5V6h-2v5H6v2h5Z" clipRule="evenodd" fillRule="evenodd" />
     </svg>
 );
 const kindTrash = (
-    <svg height="20px" width="20px" viewBox="0 -0.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" >
+    <svg width="20px" height="20px" viewBox="0 -.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg">
         <title>Delete</title>
-        <g id="Page-1" stroke="none" strokeWidth="1" fillRule="evenodd">
-            <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" >
-                <g id="types" transform="translate(56.000000, 160.000000)">
-                    <path d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z" id="delete-[#1487]">
-                    </path>
+        <g fillRule="evenodd" strokeWidth="1">
+            <g transform="translate(-180 -360)">
+                <g transform="translate(56 160)">
+                    <path d="m130.35 216h2.1v-8h-2.1v8zm4.2 0h2.1v-8h-2.1v8zm-6.3 2h10.5v-12h-10.5v12zm2.1-14h6.3v-2h-6.3v2zm8.4 0v-4h-10.5v4h-5.25v2h3.15v14h14.7v-14h3.15v-2h-5.25z"></path>
                 </g>
             </g>
         </g>
-    </svg>);
-const kindUpdate = (
-    <svg height="20px" width="20px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        <title>Update</title>
-        <g id="edit">
-            <g><path d="M6.5,24H0v-6.5L17.5,0L24,6.5L6.5,24z M2,22h3.7L18,9.7L14.3,6L2,18.3V22z M15.7,4.6l3.7,3.7l1.8-1.8l-3.7-3.7L15.7,4.6z" /></g>
-        </g>
     </svg>
 );
-
+const kindUpdate = (
+    <svg width="20px" height="20px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <title>Update</title>
+        <path d="M6.5,24H0v-6.5L17.5,0L24,6.5L6.5,24z M2,22h3.7L18,9.7L14.3,6L2,18.3V22z M15.7,4.6l3.7,3.7l1.8-1.8l-3.7-3.7L15.7,4.6z" />
+    </svg>
+);

--- a/app/components/ui/CrudButton.tsx
+++ b/app/components/ui/CrudButton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+interface CrudButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    kind: 'create' | 'update' | 'delete';
+}
+
+const btnStyle = "p-2 m-1 rounded bg-violet-600 hover:bg-violet-700 active:bg-violet-700 focus:outline-none focus:ring focus:ring-violet-300 fill-white transition-all";
+
+const CrudButton: React.FC<CrudButtonProps> = ({ kind, ...props }) => {
+    const kindCreate = (
+        <svg width="20" height="20" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" >
+            <title>Plus</title>
+            <path fillRule="evenodd" d="M11 13v5h2v-5h5v-2h-5V6h-2v5H6v2h5Z" clipRule="evenodd" />
+        </svg>
+    );
+    const kindTrash = (
+        <svg height="20px" width="20px" viewBox="0 -0.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" >
+            <title>Trash</title>
+            <g id="Page-1" stroke="none" strokeWidth="1" fillRule="evenodd">
+                <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" >
+                    <g id="types" transform="translate(56.000000, 160.000000)">
+                        <path d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z" id="delete-[#1487]">
+                        </path>
+                    </g>
+                </g>
+            </g>
+        </svg>);
+    const kindUpdate = (
+        <svg height="20px" width="20px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <title>Pen</title>
+            <g id="edit">
+                <g><path d="M6.5,24H0v-6.5L17.5,0L24,6.5L6.5,24z M2,22h3.7L18,9.7L14.3,6L2,18.3V22z M15.7,4.6l3.7,3.7l1.8-1.8l-3.7-3.7L15.7,4.6z" /></g>
+            </g>
+        </svg>
+    );
+
+    switch (kind) {
+        case 'create':
+            return (
+                <button {...props} className={btnStyle}>
+                    {kindCreate}<span className="sr-only"> {kind}</span >
+                </button >
+            );
+        case 'update':
+            return (
+                <button {...props} className={btnStyle}>
+                    {kindUpdate}<span className="sr-only">{kind}</span>
+                </button >
+            );
+        case 'delete':
+            return (
+                <button {...props} className={btnStyle}>
+                    {kindTrash}<span className="sr-only">{kind}</span>
+                </button >
+            );
+    }
+
+};
+
+export default CrudButton;
+

--- a/app/components/ui/CrudButton.tsx
+++ b/app/components/ui/CrudButton.tsx
@@ -9,13 +9,13 @@ const btnStyle = "p-2 m-1 rounded bg-violet-600 hover:bg-violet-700 active:bg-vi
 const CrudButton: React.FC<CrudButtonProps> = ({ kind, ...props }) => {
     const kindCreate = (
         <svg width="20" height="20" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" >
-            <title>Plus</title>
+            <title>Create</title>
             <path fillRule="evenodd" d="M11 13v5h2v-5h5v-2h-5V6h-2v5H6v2h5Z" clipRule="evenodd" />
         </svg>
     );
     const kindTrash = (
         <svg height="20px" width="20px" viewBox="0 -0.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" >
-            <title>Trash</title>
+            <title>Delete</title>
             <g id="Page-1" stroke="none" strokeWidth="1" fillRule="evenodd">
                 <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" >
                     <g id="types" transform="translate(56.000000, 160.000000)">
@@ -27,7 +27,7 @@ const CrudButton: React.FC<CrudButtonProps> = ({ kind, ...props }) => {
         </svg>);
     const kindUpdate = (
         <svg height="20px" width="20px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
-            <title>Pen</title>
+            <title>Update</title>
             <g id="edit">
                 <g><path d="M6.5,24H0v-6.5L17.5,0L24,6.5L6.5,24z M2,22h3.7L18,9.7L14.3,6L2,18.3V22z M15.7,4.6l3.7,3.7l1.8-1.8l-3.7-3.7L15.7,4.6z" /></g>
             </g>

--- a/app/components/ui/CrudButton.tsx
+++ b/app/components/ui/CrudButton.tsx
@@ -4,58 +4,51 @@ interface CrudButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> 
     kind: 'create' | 'update' | 'delete';
 }
 
-const btnStyle = "p-2 m-1 rounded bg-violet-600 hover:bg-violet-700 active:bg-violet-700 focus:outline-none focus:ring focus:ring-violet-300 fill-white transition-all";
-
 const CrudButton: React.FC<CrudButtonProps> = ({ kind, ...props }) => {
-    const kindCreate = (
-        <svg width="20" height="20" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" >
-            <title>Create</title>
-            <path fillRule="evenodd" d="M11 13v5h2v-5h5v-2h-5V6h-2v5H6v2h5Z" clipRule="evenodd" />
-        </svg>
-    );
-    const kindTrash = (
-        <svg height="20px" width="20px" viewBox="0 -0.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" >
-            <title>Delete</title>
-            <g id="Page-1" stroke="none" strokeWidth="1" fillRule="evenodd">
-                <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" >
-                    <g id="types" transform="translate(56.000000, 160.000000)">
-                        <path d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z" id="delete-[#1487]">
-                        </path>
-                    </g>
-                </g>
-            </g>
-        </svg>);
-    const kindUpdate = (
-        <svg height="20px" width="20px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
-            <title>Update</title>
-            <g id="edit">
-                <g><path d="M6.5,24H0v-6.5L17.5,0L24,6.5L6.5,24z M2,22h3.7L18,9.7L14.3,6L2,18.3V22z M15.7,4.6l3.7,3.7l1.8-1.8l-3.7-3.7L15.7,4.6z" /></g>
-            </g>
-        </svg>
-    );
-
+    let icon;
     switch (kind) {
         case 'create':
-            return (
-                <button {...props} className={btnStyle}>
-                    {kindCreate}<span className="sr-only"> {kind}</span >
-                </button >
-            );
+            icon = kindCreate;
+            break;
         case 'update':
-            return (
-                <button {...props} className={btnStyle}>
-                    {kindUpdate}<span className="sr-only">{kind}</span>
-                </button >
-            );
+            icon = kindUpdate;
+            break;
         case 'delete':
-            return (
-                <button {...props} className={btnStyle}>
-                    {kindTrash}<span className="sr-only">{kind}</span>
-                </button >
-            );
+            icon = kindTrash;
+            break;
     }
-
+    return (
+        <button {...props} className="p-2 m-1 rounded bg-violet-600 hover:bg-violet-700 active:bg-violet-700 focus:outline-none focus:ring focus:ring-violet-300 fill-white transition-all">
+            {icon}<span className="sr-only">{kind}</span>
+        </button >
+    );
 };
-
 export default CrudButton;
+
+const kindCreate = (
+    <svg width="20" height="20" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" >
+        <title>Create</title>
+        <path fillRule="evenodd" d="M11 13v5h2v-5h5v-2h-5V6h-2v5H6v2h5Z" clipRule="evenodd" />
+    </svg>
+);
+const kindTrash = (
+    <svg height="20px" width="20px" viewBox="0 -0.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" >
+        <title>Delete</title>
+        <g id="Page-1" stroke="none" strokeWidth="1" fillRule="evenodd">
+            <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" >
+                <g id="types" transform="translate(56.000000, 160.000000)">
+                    <path d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z" id="delete-[#1487]">
+                    </path>
+                </g>
+            </g>
+        </g>
+    </svg>);
+const kindUpdate = (
+    <svg height="20px" width="20px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <title>Update</title>
+        <g id="edit">
+            <g><path d="M6.5,24H0v-6.5L17.5,0L24,6.5L6.5,24z M2,22h3.7L18,9.7L14.3,6L2,18.3V22z M15.7,4.6l3.7,3.7l1.8-1.8l-3.7-3.7L15.7,4.6z" /></g>
+        </g>
+    </svg>
+);
 


### PR DESCRIPTION
Prop `type` was renamed to `kind` as to not clash with html button `type` attribute. This component extends html button, one can pass any [html button attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attributes) or event like `onClick`, `onMouseEnter` and so on. If having the prop name `type` is strictly necessary say so I can refactor by not extending html button.

Usage
```tsx
<CrudButton
  kind='update'
  onClick={handleClick(ticket.id)}
/>
```
Preview
![image](https://github.com/thinkbig-project/thinkbig/assets/61759797/b7d11f06-b2c6-4160-bad0-177cf378fd6d)
Hover:
![image](https://github.com/thinkbig-project/thinkbig/assets/61759797/baa04ebc-4f04-4e31-b9a7-c50aba796d85)
Active:
![image](https://github.com/thinkbig-project/thinkbig/assets/61759797/0b22a75c-4de6-47ad-9ef6-fcefe6dfda80)


