### PR TITLE
#41 create tag component

### DIFF
--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -4,12 +4,16 @@ interface TagProps extends React.ButtonHTMLAttributes<HTMLButtonElement>{
     tagType: "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
 }
 
-//TODO limit tagType prop to "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
-
 export default function Tag({tagType}: TagProps) {
+    
+    // BASE FORMATTING FOR ALL TAGS
 
+    const mainTagStyle = 'px-2 py-1 rounded font-bold font-sans'
+
+    // CONDITIONAL FORMATTING BASED ON 'tagType' of tag. 
+    
     let conditionalTagStyle : string = ''
-    // CONDITIONAL FORMATTING BASED ON 'tagType' of tag.  types defined as : 
+    
     switch (tagType) {
         case 'css':
           conditionalTagStyle = 'bg-[#0959df] text-white';
@@ -35,10 +39,12 @@ export default function Tag({tagType}: TagProps) {
         default:
           conditionalTagStyle = 'bg-yellow-400 text-black'
       }
-    
-    const mainTagStyle = 'px-2 py-1 rounded font-bold'
 
+         //100DEVS, WE GO GET!
+ 
     return (
         <span className={conditionalTagStyle +' '+ mainTagStyle}>{tagType}</span>
     )
+
+ 
 }

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -7,35 +7,31 @@ export interface TagProps {
 //TODO limit type prop to "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
 
 export default function Tag({type}: TagProps) {
-    console.log('loading tag', type)
-    
 
     let tagStyle : string = ''
-    console.log(tagStyle)
 
     switch (type) {
         case 'css':
-          tagStyle = 'bg-blue-300 text-white';
+          tagStyle = 'bg-[#0959df] text-white';
           break;
         case 'ejs':
-          tagStyle = 'bg-red-300 text-black'
+          tagStyle = 'bg-[#dfdd09] text-black'
           break;
         case 'html':
           tagStyle = 'bg-[#2d2b6b] text-black'
           break;
         case 'mongo':
-          tagStyle = 'bg-green-700 text-white'
+          tagStyle = 'bg-[#00c55b] text-white'
           break;
         case 'node':
-          tagStyle = 'bg-green-300 text-black'
+          tagStyle = 'bg-[#6aa05c] text-black'
           break;
         case 'react':
-          tagStyle = 'bg-blue-400 text-white'
+          tagStyle = 'bg-[#5fdafb] text-white'
           break;  
         default:
           tagStyle = 'bg-yellow-400 text-black'
       }
-    console.log('swtich applied', tagStyle)
     
     const mainTagStyle = 'px-2 py-1 rounded font-bold'
 

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -25,7 +25,7 @@ export default function Tag({tagType}: TagProps) {
           conditionalTagStyle = 'bg-[#2d2b6b] text-white'
           break;
         case 'js':
-          conditionalTagStyle = 'bg-[#dfdd09] text-white'
+          conditionalTagStyle = 'bg-[#dfdd09] text-black'
           break;
         case 'mongo/mongoose':
           conditionalTagStyle = 'bg-[#00c55b] text-white'

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -8,7 +8,7 @@ export default function Tag({tagType}: TagProps) {
     
     // BASE FORMATTING FOR ALL TAGS
 
-    const mainTagStyle = 'px-2 py-1 rounded font-bold font-sans'
+    const mainTagStyle = 'text-xs font-medium font-sans me-2 px-2.5 py-0.5 rounded'
 
     // CONDITIONAL FORMATTING BASED ON 'tagType' of tag. 
     

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-interface TagProps extends React.ButtonHTMLAttributes<HTMLButtonElement>{
+interface TagProps {
     tagType: "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
 }
 

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-export interface TagProps {
-    tagType: string
+interface TagProps extends React.ButtonHTMLAttributes<HTMLButtonElement>{
+    tagType: "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
 }
 
 //TODO limit tagType prop to "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -28,16 +28,17 @@ export default function Tag({tagType}: TagProps) {
           conditionalTagStyle = 'bg-[#dfdd09] text-black'
           break;
         case 'mongo/mongoose':
-          conditionalTagStyle = 'bg-[#00c55b] text-white'
+          conditionalTagStyle = 'bg-[#00c55b] text-black'
           break;
         case 'node/express':
-          conditionalTagStyle = 'bg-[#6aa05c] text-white'
+          conditionalTagStyle = 'bg-[#6Da460] text-black'
           break;
         case 'react':
-          conditionalTagStyle = 'bg-[#5fdafb] text-white'
+          conditionalTagStyle = 'bg-[#5fdafb] text-black'
           break;  
         default:
-          conditionalTagStyle = 'bg-yellow-400 text-black'
+          //this should never actually appear since types are restricted
+          conditionalTagStyle = '#EAD02A text-black'
       }
 
          //100DEVS, WE GO GET!

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -1,41 +1,44 @@
 import React from 'react'
 
 export interface TagProps {
-    type: string
+    tagType: string
 }
 
-//TODO limit type prop to "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
+//TODO limit tagType prop to "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
 
-export default function Tag({type}: TagProps) {
+export default function Tag({tagType}: TagProps) {
 
-    let tagStyle : string = ''
-
-    switch (type) {
+    let conditionalTagStyle : string = ''
+    // CONDITIONAL FORMATTING BASED ON 'tagType' of tag.  types defined as : 
+    switch (tagType) {
         case 'css':
-          tagStyle = 'bg-[#0959df] text-white';
+          conditionalTagStyle = 'bg-[#0959df] text-white';
           break;
         case 'ejs':
-          tagStyle = 'bg-[#dfdd09] text-black'
+          conditionalTagStyle = 'bg-[#98265b] text-white'
           break;
         case 'html':
-          tagStyle = 'bg-[#2d2b6b] text-black'
+          conditionalTagStyle = 'bg-[#2d2b6b] text-white'
           break;
-        case 'mongo':
-          tagStyle = 'bg-[#00c55b] text-white'
+        case 'js':
+          conditionalTagStyle = 'bg-[#dfdd09] text-white'
           break;
-        case 'node':
-          tagStyle = 'bg-[#6aa05c] text-black'
+        case 'mongo/mongoose':
+          conditionalTagStyle = 'bg-[#00c55b] text-white'
+          break;
+        case 'node/express':
+          conditionalTagStyle = 'bg-[#6aa05c] text-white'
           break;
         case 'react':
-          tagStyle = 'bg-[#5fdafb] text-white'
+          conditionalTagStyle = 'bg-[#5fdafb] text-white'
           break;  
         default:
-          tagStyle = 'bg-yellow-400 text-black'
+          conditionalTagStyle = 'bg-yellow-400 text-black'
       }
     
     const mainTagStyle = 'px-2 py-1 rounded font-bold'
 
     return (
-        <span className={tagStyle +' '+ mainTagStyle}>{type}</span>
+        <span className={conditionalTagStyle +' '+ mainTagStyle}>{tagType}</span>
     )
 }

--- a/app/components/ui/Tag.tsx
+++ b/app/components/ui/Tag.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+export interface TagProps {
+    type: string
+}
+
+//TODO limit type prop to "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react"
+
+export default function Tag({type}: TagProps) {
+    console.log('loading tag', type)
+    
+
+    let tagStyle : string = ''
+    console.log(tagStyle)
+
+    switch (type) {
+        case 'css':
+          tagStyle = 'bg-blue-300 text-white';
+          break;
+        case 'ejs':
+          tagStyle = 'bg-red-300 text-black'
+          break;
+        case 'html':
+          tagStyle = 'bg-[#2d2b6b] text-black'
+          break;
+        case 'mongo':
+          tagStyle = 'bg-green-700 text-white'
+          break;
+        case 'node':
+          tagStyle = 'bg-green-300 text-black'
+          break;
+        case 'react':
+          tagStyle = 'bg-blue-400 text-white'
+          break;  
+        default:
+          tagStyle = 'bg-yellow-400 text-black'
+      }
+    console.log('swtich applied', tagStyle)
+    
+    const mainTagStyle = 'px-2 py-1 rounded font-bold'
+
+    return (
+        <span className={tagStyle +' '+ mainTagStyle}>{type}</span>
+    )
+}


### PR DESCRIPTION
## Created a tag component per issue description.

"a rectangle with slight padding and slightly rounded corners. It will display a unique color and title based on the type prop. We will directly tie a color to each possible type prop. The goal is for them to be compact so that many can be listed together in a small space.

Name it Tag.tsx and place it in @/app/components/ui
Type prop: Limited to "css" | "ejs" | "html" | "js" | "mongo/mongoose" | "node/express" | "react". (Will be expanded later)
Usage example:

<Tag type='css' />"

thanks to @vasfvitor for the assist on typescript type-ing :)

here is what they look like as of this PR.  I hope the styling is familiar and appealing.

![tagideas](https://github.com/thinkbig-project/thinkbig/assets/101375846/fc37aa54-2551-46f1-a4e0-374d63aa6e54)

I could probably use some eyes on how I've handled the conditional formatting based on tagType.  

I'm also feeling uncomfortable with using the keyword 'type' as the prop name, but I suppose it works and is defined in the scope of the issue.

Happy to end the year with a PR on this project!  Happy New Year, Devs!

