### PR TITLE
40 create typetag component

### DIFF
--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -20,4 +20,4 @@ const Button: React.FC<ButtonProps> = ({ title, href }) => {
   );
 };
 
-export default Button;
+export default Button; 

--- a/app/components/ui/IssueIcon.tsx
+++ b/app/components/ui/IssueIcon.tsx
@@ -34,7 +34,7 @@ const IssueIcon: React.FC<IssueIconProps> = ({ type }) => {
   const imageSrc = getImageSrc();
 
   return (
-    <div className='aspect-auto p-2'>
+    <div className='aspect-auto p-1'>
       <Image src={imageSrc} alt={`${type} icon`} width={32} height={32} />
     </div>
   );

--- a/app/components/ui/IssueIcon.tsx
+++ b/app/components/ui/IssueIcon.tsx
@@ -7,11 +7,11 @@ import conceptIcon from '@/app/favicon.ico';
 import lfsgIcon from '@/app/favicon.ico';
 import watchAlongIcon from '@/app/favicon.ico';
 
-interface TypeTagProps {
+interface IssueIconProps {
   type: 'assignment' | 'class' | 'code' | 'concept' | 'lfsg' | 'watchAlong';
 }
 
-const TypeTag: React.FC<TypeTagProps> = ({ type }) => {
+const IssueIcon: React.FC<IssueIconProps> = ({ type }) => {
   const getImageSrc = () => {
     switch (type) {
       case 'assignment':
@@ -34,10 +34,10 @@ const TypeTag: React.FC<TypeTagProps> = ({ type }) => {
   const imageSrc = getImageSrc();
 
   return (
-    <div className="type-tag">
+    <div className='aspect-auto p-2'>
       <Image src={imageSrc} alt={`${type} icon`} width={32} height={32} />
     </div>
   );
 };
 
-export default TypeTag;
+export default IssueIcon;

--- a/app/components/ui/TypeTag.tsx
+++ b/app/components/ui/TypeTag.tsx
@@ -1,0 +1,43 @@
+
+import Image from 'next/image';
+import assignmentIcon from '@/path/to/assignment-icon.png';
+import classIcon from '@/path/to/class-icon.png';
+import codeIcon from '@/path/to/code-icon.png';
+import conceptIcon from '@/path/to/concept-icon.png';
+import lfsgIcon from '@/path/to/lfsg-icon.png';
+import watchAlongIcon from '@/path/to/watch-along-icon.png';
+
+interface TypeTagProps {
+  type: 'assignment' | 'class' | 'code' | 'concept' | 'lfsg' | 'watchAlong';
+}
+
+const TypeTag: React.FC<TypeTagProps> = ({ type }) => {
+  const getImageSrc = () => {
+    switch (type) {
+      case 'assignment':
+        return assignmentIcon;
+      case 'class':
+        return classIcon;
+      case 'code':
+        return codeIcon;
+      case 'concept':
+        return conceptIcon;
+      case 'lfsg':
+        return lfsgIcon;
+      case 'watchAlong':
+        return watchAlongIcon;
+      default:
+        return ''; // Placeholder for default or unknown type
+    }
+  };
+
+  const imageSrc = getImageSrc();
+
+  return (
+    <div className="type-tag">
+      <Image src={imageSrc} alt={`${type} icon`} width={32} height={32} />
+    </div>
+  );
+};
+
+export default TypeTag;

--- a/app/components/ui/TypeTag.tsx
+++ b/app/components/ui/TypeTag.tsx
@@ -1,11 +1,11 @@
 
 import Image from 'next/image';
-import assignmentIcon from '@/path/to/assignment-icon.png';
-import classIcon from '@/path/to/class-icon.png';
-import codeIcon from '@/path/to/code-icon.png';
-import conceptIcon from '@/path/to/concept-icon.png';
-import lfsgIcon from '@/path/to/lfsg-icon.png';
-import watchAlongIcon from '@/path/to/watch-along-icon.png';
+import assignmentIcon from '@/app/favicon.ico';
+import classIcon from '@/app/favicon.ico';
+import codeIcon from '@/app/favicon.ico';
+import conceptIcon from '@/app/favicon.ico';
+import lfsgIcon from '@/app/favicon.ico';
+import watchAlongIcon from '@/app/favicon.ico';
 
 interface TypeTagProps {
   type: 'assignment' | 'class' | 'code' | 'concept' | 'lfsg' | 'watchAlong';

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,17 @@
+import TypeTag from "../components/ui/TypeTag";
+
 const Dashboard = async () => {
   return (
     <>
       <h1>Dashboard</h1>
+      <div>
+        <TypeTag type="assignment" />
+        <TypeTag type="class" />
+        <TypeTag type="code" />
+        <TypeTag type="concept" />
+        <TypeTag type="lfsg" />
+        <TypeTag type="watchAlong" />
+      </div>
     </>
   );
 };

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,16 +1,16 @@
-import TypeTag from "../components/ui/TypeTag";
+import IssueIcon from "../components/ui/IssueIcon";
 
 const Dashboard = async () => {
   return (
     <>
       <h1>Dashboard</h1>
       <div>
-        <TypeTag type="assignment" />
-        <TypeTag type="class" />
-        <TypeTag type="code" />
-        <TypeTag type="concept" />
-        <TypeTag type="lfsg" />
-        <TypeTag type="watchAlong" />
+        <IssueIcon type="assignment" />
+        <IssueIcon type="class" />
+        <IssueIcon type="code" />
+        <IssueIcon type="concept" />
+        <IssueIcon type="lfsg" />
+        <IssueIcon type="watchAlong" />
       </div>
     </>
   );


### PR DESCRIPTION
I couldn't get authenticated to login, but I am able to view /dashboard in localhost. 

I've created a component - IssueIcon.tsx

For the icons themselves, I have temporarily used our favicon as placeholders.

The code sets the prop { type } options as specified in the issue description. A switch statement is used for each of these type options.  A div is returned with a nested <Image /> 

Finally, I've imported the component into page.tsx of the dashboard. The IssueIcons have been placed in a div element.

Please let me know if there are any issues or anything else that may need to be adjusted or added. 
